### PR TITLE
support transaction data for on chain verification

### DIFF
--- a/protocol/contract_invoke.go
+++ b/protocol/contract_invoke.go
@@ -9,28 +9,7 @@ import (
 const (
 	// ContractInvokeRequestMessageType defines contract invoke request type of the communication protocol
 	ContractInvokeRequestMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "proofs/1.0/contract-invoke-request"
-	// ContractInvokeResponseMessageType defines contract invoke response type of the communication protocol
-	ContractInvokeResponseMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "proofs/1.0/contract-invoke-response"
 )
-
-// ContractInvokeResponseMessage is struct the represents iden3message contract invoke response
-type ContractInvokeResponseMessage struct {
-	ID       string                            `json:"id"`
-	Typ      iden3comm.MediaType               `json:"typ,omitempty"`
-	Type     iden3comm.ProtocolMessage         `json:"type"`
-	ThreadID string                            `json:"thid,omitempty"`
-	Body     ContractInvokeMessageResponseBody `json:"body,omitempty"`
-
-	From string `json:"from,omitempty"`
-	To   string `json:"to,omitempty"`
-}
-
-// ContractInvokeMessageResponseBody is struct the represents contract invoke response data
-type ContractInvokeMessageResponseBody struct {
-	DIDDoc  json.RawMessage              `json:"did_doc,omitempty"`
-	Message string                       `json:"message,omitempty"`
-	Scope   []ZeroKnowledgeProofResponse `json:"scope"`
-}
 
 // ContractInvokeRequestMessage is struct the represents iden3message contract invoke request
 type ContractInvokeRequestMessage struct {
@@ -46,7 +25,6 @@ type ContractInvokeRequestMessage struct {
 
 // ContractInvokeRequestMessageBody is body for contract invoke request
 type ContractInvokeRequestMessageBody struct {
-	CallbackURL     string                      `json:"callbackUrl"`
 	Reason          string                      `json:"reason,omitempty"`
 	Message         string                      `json:"message,omitempty"`
 	TransactionData TransactionData             `json:"transaction_data"`

--- a/protocol/contract_invoke.go
+++ b/protocol/contract_invoke.go
@@ -8,9 +8,9 @@ import (
 
 const (
 	// ContractInvokeRequestMessageType defines contract invoke request type of the communication protocol
-	ContractInvokeRequestMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "contract/invoke/1.0/request"
+	ContractInvokeRequestMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "proofs/1.0/contract-invoke-request"
 	// ContractInvokeResponseMessageType defines contract invoke response type of the communication protocol
-	ContractInvokeResponseMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "contract/invoke/1.0/response"
+	ContractInvokeResponseMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "proofs/1.0/contract-invoke-response"
 )
 
 // ContractInvokeResponseMessage is struct the represents iden3message contract invoke response

--- a/protocol/contract_invoke.go
+++ b/protocol/contract_invoke.go
@@ -1,0 +1,63 @@
+package protocol
+
+import (
+	"encoding/json"
+
+	"github.com/iden3/iden3comm"
+)
+
+const (
+	// ContractInvokeRequestMessageType defines contract invoke request type of the communication protocol
+	ContractInvokeRequestMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "contract/invoke/1.0/request"
+	// ContractInvokeResponseMessageType defines contract invoke response type of the communication protocol
+	ContractInvokeResponseMessageType iden3comm.ProtocolMessage = iden3comm.Iden3Protocol + "contract/invoke/1.0/response"
+)
+
+// ContractInvokeResponseMessage is struct the represents iden3message contract invoke response
+type ContractInvokeResponseMessage struct {
+	ID       string                            `json:"id"`
+	Typ      iden3comm.MediaType               `json:"typ,omitempty"`
+	Type     iden3comm.ProtocolMessage         `json:"type"`
+	ThreadID string                            `json:"thid,omitempty"`
+	Body     ContractInvokeMessageResponseBody `json:"body,omitempty"`
+
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
+}
+
+// ContractInvokeMessageResponseBody is struct the represents contract invoke response data
+type ContractInvokeMessageResponseBody struct {
+	DIDDoc  json.RawMessage              `json:"did_doc,omitempty"`
+	Message string                       `json:"message,omitempty"`
+	Scope   []ZeroKnowledgeProofResponse `json:"scope"`
+}
+
+// ContractInvokeRequestMessage is struct the represents iden3message contract invoke request
+type ContractInvokeRequestMessage struct {
+	ID       string                           `json:"id"`
+	Typ      iden3comm.MediaType              `json:"typ,omitempty"`
+	Type     iden3comm.ProtocolMessage        `json:"type"`
+	ThreadID string                           `json:"thid,omitempty"`
+	Body     ContractInvokeRequestMessageBody `json:"body,omitempty"`
+
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
+}
+
+// ContractInvokeRequestMessageBody is body for contract invoke request
+type ContractInvokeRequestMessageBody struct {
+	CallbackURL     string                      `json:"callbackUrl"`
+	Reason          string                      `json:"reason,omitempty"`
+	Message         string                      `json:"message,omitempty"`
+	TransactionData TransactionData             `json:"transaction_data"`
+	DIDDoc          json.RawMessage             `json:"did_doc,omitempty"`
+	Scope           []ZeroKnowledgeProofRequest `json:"scope"`
+}
+
+// TransactionData represents structure for on chain verification
+type TransactionData struct {
+	ContractAddress string `json:"contract_address"`
+	MethodID        string `json:"method_id"`
+	ChainID         int    `json:"chain_id"`
+	Network         string `json:"network"`
+}


### PR DESCRIPTION
We should support contract invoke protocol message:
```json
{
    "id": "c811849d-6bfb-4d85-936e-3d9759c7f105",
    "typ": "application/iden3comm-plain-json",
    "type": "https://iden3-communication.io/proofs/1.0/contract-invoke-request",
    "body": {
        "transaction_data": {
            "contract_address": "0x1a0380E226aC7dbef5A4e12A87424356EA30231C",
            "method_id": "c32e370e",
            "chain_id": 80001,
            "network": "polygon-mumbai"
        },
        "reason": "for testing",
        "scope": [
            {
                "id": 1,
                "circuitId": "credentialAtomicQueryMTPV2Onchain",
                "query": {
                    "allowedIssuers": [
                        "*"
                    ],
                    "credentialSubject": {
                        "birthday": {
                            "$lt": 20000101
                        }
                    },
                    "context": "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld",
                    "type": "KYCAgeCredential"
                }
            }
        ]
    }
}
```