### PR TITLE
Add build tag no_jwz to get rid of dependency on librapidsnark.a if you don't need it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as below, without any additional terms or conditions.
 
+## Build constraints
+
+### no_jwz
+
+If you do not use the JWZ functionality and do not need to run prover on
+JWZ packed messages, you can build the library with the `no_jwz` build tag.
+This build tag would prevent the dependency on the `librapidsnark.a` library
+
 ## License
 
 &copy; 2023 0kims Association

--- a/mock/proving.go
+++ b/mock/proving.go
@@ -1,3 +1,5 @@
+//go:build !no_jwz
+
 // Package mock defines mocks for protocol testing
 package mock
 

--- a/packers/zkp.go
+++ b/packers/zkp.go
@@ -1,3 +1,5 @@
+//go:build !no_jwz
+
 package packers
 
 import (


### PR DESCRIPTION
When you use this library as dependency, you need to link against `librapidsnark.a` library because of the groth16_prover call. It causes some troubles if you use the iden3comm module as a dependency of another `.a` library. As an outcome, now you need to link the final C project against two libraries, the one you develop and also `librapidsnark.a`. Even you your library use nothing from rapidsnark. 

So I have introduced the build tag `no_jwz` to turn the rapidsnark dependency off if you are sure you do not need it. 