### PR TITLE
add RSA OAEP

### DIFF
--- a/packers/zkp_test.go
+++ b/packers/zkp_test.go
@@ -131,7 +131,7 @@ func TestZKPSupportedProfilesWithoutCircuits(t *testing.T) {
 func TestConvertEthResolvers(t *testing.T) {
 	resolver1, err := eth.NewResolver("https://rpc-mainnet.billions.network", "0x3C9acB2205Aa72A05F6D77d708b5Cf85FCa3a123")
 	require.NoError(t, err)
-	resolver2, err := eth.NewResolver("http://billions-testnet-rpc.eu-north-2.gateway.fm", "0x3C9acB2205Aa72A05F6D77d708b5Cf85FCa3a896")
+	resolver2, err := eth.NewResolver("https://billions-testnet-rpc.eu-north-2.gateway.fm", "0x3C9acB2205Aa72A05F6D77d708b5Cf85FCa3a896")
 	require.NoError(t, err)
 
 	ethResolvers := map[int]eth.Resolver{

--- a/utils/accept.go
+++ b/utils/accept.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iden3/go-circuits/v2"
 	"github.com/iden3/iden3comm/v2"
 	"github.com/iden3/iden3comm/v2/protocol"
+	"github.com/lestrrat-go/jwx/v3/jwa"
 )
 
 const (
@@ -232,7 +233,8 @@ func isAcceptJwsAlgorithms(value string) bool {
 func isAcceptAnoncryptAlgorithms(value string) bool {
 	// List all possible Anoncrypt algorithms
 	validAlgorithms := []protocol.AnoncryptAlgorithms{
-		protocol.AnoncryptECDHESA256KW,
+		protocol.AnoncryptAlgorithms(jwa.RSA_OAEP_256().String()),
+		protocol.AnoncryptAlgorithms(jwa.ECDH_ES_A256KW().String()),
 	}
 	for _, v := range validAlgorithms {
 		if protocol.AnoncryptAlgorithms(value) == v {


### PR DESCRIPTION
This pull request updates the supported algorithms for anonymous encryption in the `utils/accept.go` file, aligning them with the definitions provided by the `jwa` package from `lestrrat-go/jwx/v3`. The change ensures that the code uses standardized algorithm identifiers.

**Cryptographic algorithm updates:**

* Updated the list of valid Anoncrypt algorithms in `isAcceptAnoncryptAlgorithms` to use `jwa.RSA_OAEP_256()` and `jwa.ECDH_ES_A256KW()` string representations, instead of the previous `protocol.AnoncryptECDHESA256KW` constant.
* Added an import for the `jwa` package from `lestrrat-go/jwx/v3` to enable usage of these standardized algorithm names.